### PR TITLE
Add PDF download for deliverable dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
     "sonner": "^2.0.1",
-    "zod": "^3.24.3"
+    "zod": "^3.24.3",
+    "jspdf": "^2.5.1",
+    "html2canvas": "^1.4.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- allow downloading deliverable result as PDF
- add html2canvas and jspdf dependencies

## Testing
- `pnpm lint` *(fails: next not found because dependencies aren't installed)*
- `pnpm test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_6842b8b968f08323886f4423a1f4a8b1